### PR TITLE
Fix nil error checks

### DIFF
--- a/errsizedgroup.go
+++ b/errsizedgroup.go
@@ -106,7 +106,7 @@ func (m *multierror) append(err error) *multierror {
 	return m
 }
 
-func (m *multierror) errorOrNil() *multierror {
+func (m *multierror) errorOrNil() error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	if len(m.errors) == 0 {


### PR DESCRIPTION
Hi @umputun,

I just found a small bug in `ErrSizedGroup` `Wait()` function.

The code below will always fail:
```go
	grp := NewErrSizedGroup(10)

	// wait for completion
	if err := grp.Wait(); err != nil {
		panic(err)
	}
```

The fix is very simple:
**before:**
`func (m *multierror) errorOrNil() *multierror {`
**after:**
`func (m *multierror) errorOrNil() error {`

More details: https://dev.to/pauljlucas/go-tcha-when-nil--nil-hic ("nil != nil" in Go)
