### PR TITLE
Semaphore field

### DIFF
--- a/semaphore.go
+++ b/semaphore.go
@@ -8,7 +8,7 @@ type Locker interface {
 	TryLock() bool
 }
 
-// Semaphore implementation, counted lock only. Implements sync.Locker interface, thread safe.
+// Semaphore implementation, counted lock only. Implements Locker interface, thread safe.
 type semaphore struct {
 	ch chan struct{}
 }

--- a/semaphore.go
+++ b/semaphore.go
@@ -10,7 +10,6 @@ type Locker interface {
 
 // Semaphore implementation, counted lock only. Implements sync.Locker interface, thread safe.
 type semaphore struct {
-	Locker
 	ch chan struct{}
 }
 


### PR DESCRIPTION
Hi,
after adding the Locker interface in [Discard mode #4](https://github.com/go-pkgz/syncs/pull/4/files#diff-285bd213002d1e3a885ef3358506f74eeabdb7d7980a554d411a4a6ddf8a3f22), it was probably also intended to remove the sync.Locker field from the semaphore struct.