### PR TITLE
ErrSizedGroup (context, multierror)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ It can work as a regular errgrp.Group or with early termination. It is thread-sa
 
 
 ```go
-	ewg := syncs.NewErrSizedGroup(5, syncs.Preemptive) // error wait group with max size=5, don't try to start more if any error happened
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ewg := syncs.NewErrSizedGroup(5, syncs.Preemptive, syncs.Context(ctx)) // error wait group with max size=5, don't try to start more if any error happened
 	for i :=0; i<10; i++ {
-		ewg.Go(func(ctx context.Context) error { // Go here could be blocked if trying to run >5 at the same time 
+		ewg.Go(func(ctx context.Context) error { // Go here could be blocked if trying to run >5 at the same time
 			err := doThings(ctx)     // only 5 of these will run in parallel
 			return err
 		})

--- a/errsizedgroup.go
+++ b/errsizedgroup.go
@@ -1,6 +1,7 @@
 package syncs
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -14,6 +15,10 @@ type ErrSizedGroup struct {
 	wg   sync.WaitGroup
 	sema Locker
 
+	termCancel func()
+	terminated func() bool
+	canceled   func() bool
+
 	err     *MultiError
 	errLock sync.RWMutex
 	errOnce sync.Once
@@ -25,12 +30,31 @@ type ErrSizedGroup struct {
 // TermOnErr will skip (won't start) all other goroutines if any error returned.
 func NewErrSizedGroup(size int, options ...GroupOption) *ErrSizedGroup {
 	res := ErrSizedGroup{
-		sema: NewSemaphore(size),
-		err:  new(MultiError),
+		sema:       NewSemaphore(size),
+		err:        new(MultiError),
+		terminated: func() bool { return false },
 	}
-
 	for _, opt := range options {
 		opt(&res.options)
+	}
+	if res.ctx == nil {
+		res.ctx = context.Background()
+	}
+	if res.termOnError {
+		res.ctx, res.termCancel = context.WithCancel(res.ctx)
+		res.terminated = func() bool { // terminated will be true if any error happened before
+			res.errLock.RLock()
+			defer res.errLock.RUnlock()
+			return res.err.ErrorOrNil() != nil
+		}
+	}
+	res.canceled = func() bool {
+		select {
+		case <-res.ctx.Done():
+			return true
+		default:
+			return false
+		}
 	}
 
 	return &res
@@ -39,21 +63,8 @@ func NewErrSizedGroup(size int, options ...GroupOption) *ErrSizedGroup {
 // Go calls the given function in a new goroutine.
 // The first call to return a non-nil error cancels the group if termOnError; its error will be
 // returned by Wait. If no termOnError all errors will be collected in multierror.
-func (g *ErrSizedGroup) Go(f func() error) {
-
-	canceled := func() bool {
-		if g.ctx == nil {
-			return false
-		}
-		select {
-		case <-g.ctx.Done():
-			return true
-		default:
-			return false
-		}
-	}
-
-	if canceled() {
+func (g *ErrSizedGroup) Go(f func(ctx context.Context) error) {
+	if g.canceled() && (!g.termOnError || len(g.err.Errors()) == 0) {
 		g.errOnce.Do(func() {
 			// don't repeat this error
 			g.err.append(g.ctx.Err())
@@ -62,8 +73,7 @@ func (g *ErrSizedGroup) Go(f func() error) {
 	}
 
 	g.wg.Add(1)
-
-	isLocked := false
+	var isLocked bool
 	if g.preLock {
 		lockOk := g.sema.TryLock()
 		if lockOk {
@@ -82,24 +92,16 @@ func (g *ErrSizedGroup) Go(f func() error) {
 
 	go func() {
 		defer g.wg.Done()
-
-		// terminated will be true if any error happened before and g.termOnError
-		terminated := func() bool {
-			if !g.termOnError {
-				return false
-			}
-			g.errLock.RLock()
-			defer g.errLock.RUnlock()
-			return g.err.ErrorOrNil() != nil
-		}
-
 		defer func() {
 			if isLocked {
 				g.sema.Unlock()
 			}
 		}()
 
-		if terminated() {
+		if g.terminated() {
+			if !g.canceled() {
+				g.termCancel()
+			}
 			return // terminated due prev error, don't run anything in this group anymore
 		}
 
@@ -108,10 +110,8 @@ func (g *ErrSizedGroup) Go(f func() error) {
 			isLocked = true
 		}
 
-		if err := f(); err != nil {
-			g.errLock.Lock()
-			g.err = g.err.append(err)
-			g.errLock.Unlock()
+		if err := f(g.ctx); err != nil && !g.canceled() {
+			g.err.append(err)
 		}
 	}()
 }


### PR DESCRIPTION
Hi,
yesterday I decided to take a closer look at the examples from the readme, in the process it turned out that [the last example](https://github.com/go-pkgz/syncs/blob/d557ed00dfb3ff164f2f1051fc9cb3351d7267c3/README.md?plain=1#L73) for ErrSizedGroup runs with an error `cannot use func(ctx context.Context) error {…} (value of type func(ctx context.Context) error) as func() error value in argument to egrp.Go`.

- implement the correct logic for context cancellation
- simplify the methods for the MultiError struct
- tried to reduce the number of explicit locks