### PR TITLE
Fix CI workflow: checkout before setup-go for proper caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: set up go 1.22
-        uses: actions/setup-go@v4
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: set up go
+        uses: actions/setup-go@v5
         with:
           go-version: "1.22"
         id: go
-
-      - name: checkout
-        uses: actions/checkout@v3
 
       - name: build and test
         run: |
@@ -30,9 +30,9 @@ jobs:
           TZ: "America/Chicago"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.61
+          version: v2.6
 
       - name: install goveralls
         run: go install github.com/mattn/goveralls@latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,103 +1,92 @@
-linters-settings:
-  govet:
-    shadow: true
-  golint:
-    min-confidence: 0.6
-  gocyclo:
-    min-complexity: 15
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: US
-  lll:
-    line-length: 140
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
-      - hugeParam
-      - rangeValCopy
-
-linters:
-  disable-all: true
-  enable:
-    - revive
-    - govet
-    - unconvert
-    - gosec
-    - unparam
-    - unused
-    - typecheck
-    - ineffassign
-    - stylecheck
-    - gochecknoinits
-    - gocritic
-    - nakedret
-    - gosimple
-    - prealloc
-
-  fast: false
-
-
+version: "2"
 run:
   concurrency: 4
+linters:
+  default: none
+  enable:
+    - gochecknoinits
+    - gocritic
+    - gosec
+    - govet
+    - ineffassign
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - hugeParam
+        - rangeValCopy
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
 
-issues:
-  exclude-dirs:
-    - vendor
-  exclude-rules:
-    - text: "should have a package comment, unless it's in another file for this package"
-      linters:
-        - golint
-    - text: "exitAfterDefer:"
-      linters:
-        - gocritic
-    - text: "whyNoLint: include an explanation for nolint directive"
-      linters:
-        - gocritic
-    - text: "go.mongodb.org/mongo-driver/bson/primitive.E"
-      linters:
-        - govet
-    - text: "weak cryptographic primitive"
-      linters:
-        - gosec
-    - text: "integer overflow conversion"
-      linters:
-        - gosec
-    - text: "should have a package comment"
-      linters:
-        - revive
-    - text: "at least one file in a package should have a package comment"
-      linters:
-        - stylecheck
-    - text: "commentedOutCode: may want to remove commented-out code"
-      linters:
-        - gocritic
-    - text: "unnamedResult: consider giving a name to these results"
-      linters:
-        - gocritic
-    - text: "var-naming: don't use an underscore in package name"
-      linters:
-        - revive
-    - text: "should not use underscores in package names"
-      linters:
-        - stylecheck
-    - text: "struct literal uses unkeyed fields"
-      linters:
-        - govet
-    - linters:
-        - unparam
-        - unused
-        - revive
-      path: _test\.go$
-      text: "unused-parameter"
-  exclude-use-default: false
-
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - gocritic
+        text: "exitAfterDefer:"
+      - linters:
+          - gocritic
+        text: "whyNoLint: include an explanation for nolint directive"
+      - linters:
+          - govet
+        text: "go.mongodb.org/mongo-driver/bson/primitive.E"
+      - linters:
+          - gosec
+        text: "weak cryptographic primitive"
+      - linters:
+          - gosec
+        text: "integer overflow conversion"
+      - linters:
+          - revive
+        text: "should have a package comment"
+      - linters:
+          - staticcheck
+        text: "at least one file in a package should have a package comment"
+      - linters:
+          - gocritic
+        text: "commentedOutCode: may want to remove commented-out code"
+      - linters:
+          - gocritic
+        text: "unnamedResult: consider giving a name to these results"
+      - linters:
+          - revive
+        text: "var-naming: don't use an underscore in package name"
+      - linters:
+          - staticcheck
+        text: "should not use underscores in package names"
+      - linters:
+          - govet
+        text: "struct literal uses unkeyed fields"
+      - linters:
+          - unparam
+          - unused
+          - revive
+        path: _test\.go$
+        text: "unused-parameter"
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$

--- a/sizedgroup.go
+++ b/sizedgroup.go
@@ -17,7 +17,7 @@ type SizedGroup struct {
 // NewSizedGroup makes wait group with limited size alive goroutines
 func NewSizedGroup(size int, opts ...GroupOption) *SizedGroup {
 	res := SizedGroup{sema: NewSemaphore(size)}
-	res.options.ctx = context.Background()
+	res.ctx = context.Background()
 	for _, opt := range opts {
 		opt(&res.options)
 	}


### PR DESCRIPTION
## Summary
- Move checkout step before setup-go to enable proper Go module caching
- setup-go needs go.mod/go.sum files to generate cache keys
- Update actions to latest versions (checkout@v4, setup-go@v5)
- Update golangci-lint action to v7 and version to v2.6